### PR TITLE
Expand NRW animation slope and adjust proportions

### DIFF
--- a/index.html
+++ b/index.html
@@ -942,7 +942,7 @@
                         <p class="content-text">Genau hier setzen wir an, mit Projekten, die Wissen vertiefen, Kompetenzen fördern und Demokratie erlebbar machen.</p>
                         
                         <!-- NRW-Animation in konsistentem Container -->
-                        <h4 style="color: #8dd9ff; text-align: center; margin-bottom: 15px; font-family: 'Orbitron', sans-serif;">
+                        <h4 style="color: #8dd9ff; text-align: left; margin-bottom: 8px; font-family: 'Orbitron', sans-serif;">
                           Verteilung des politischen Wissens nach Kompetenzstufen für NRW
                         </h4>
                         <iframe src="nrwanimation/index.html"

--- a/nrwanimation/index.html
+++ b/nrwanimation/index.html
@@ -79,10 +79,10 @@
 
     // Perspective camera to provide depth to the scene
     const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
-    // Pull the camera back slightly to ensure the entire layout fits comfortably
-    // within view when using the widened positions.  A Z distance of 25 gives
-    // ample room for the slope and characters without cropping.
-    camera.position.set(0, 0, 25);
+    // Pull the camera back further so the widened slope and enlarged characters
+    // fit comfortably inside the frame.  A Z distance of 35 gives
+    // ample room for the entire scene without cropping.
+    camera.position.set(0, 0, 35);
 
     // WebGL renderer
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
@@ -175,15 +175,13 @@
     }
 
     // Character definitions: Data URI (from base64Textures), label, percentage, and scale factor
-    // The heights have been increased slightly to improve readability within the fixed
-    // container on the webpage. The largest figure (A) remains dominant, while the
-    // other stages step down gradually. Feel free to tweak these values if further
-    // fine‑tuning is required.
+    // Heights are scaled up to match the broader slope, keeping the astronaut as
+    // the dominant figure while the remaining stages decrease gradually.
     const characters = [
-      { uri: base64Textures.astro, label: 'Kompetenzstufe A', value: '36%', height: 3.5 },
-      { uri: base64Textures.girl, label: 'Kompetenzstufe B', value: '34%', height: 3.1 },
-      { uri: base64Textures.boy_walk, label: 'Kompetenzstufe C', value: '20%', height: 2.6 },
-      { uri: base64Textures.boy_lean, label: 'Kompetenzstufe D', value: '10%', height: 2.3 }
+      { uri: base64Textures.astro, label: 'Kompetenzstufe A', value: '36%', height: 5.0 },
+      { uri: base64Textures.girl, label: 'Kompetenzstufe B', value: '34%', height: 4.4 },
+      { uri: base64Textures.boy_walk, label: 'Kompetenzstufe C', value: '20%', height: 3.8 },
+      { uri: base64Textures.boy_lean, label: 'Kompetenzstufe D', value: '10%', height: 3.2 }
     ];
 
     // Precompute 3D positions for the four stages along a curve that better
@@ -193,10 +191,10 @@
     // title above.  Feel free to adjust the X and Y values to fit your
     // layout perfectly.
     const positions = [
-      new THREE.Vector3(-5, 0.75, 0),  // Stage A: highest point, adjusted for new width
-      new THREE.Vector3(-1.5, 0.3, 0), // Stage B: modest drop
-      new THREE.Vector3(1.5, 0.3, 0),  // Stage C: flat segment
-      new THREE.Vector3(5, -0.8, 0)    // Stage D: lowest point with steep drop
+      new THREE.Vector3(-8, 0.75, 0),  // Stage A: highest point, far left
+      new THREE.Vector3(-2.4, 0.3, 0), // Stage B: modest drop
+      new THREE.Vector3(2.4, 0.3, 0),  // Stage C: flat segment
+      new THREE.Vector3(8, -0.8, 0)    // Stage D: lowest point with steep drop
     ];
 
     // Create slope segments as thin glowing rectangles to emulate the descending line


### PR DESCRIPTION
## Summary
- Widened the NRW competence slope and repositioned characters for a broader layout.
- Enlarged character sprites proportionally and pulled camera back for proper framing.
- Left-aligned heading for NRW animation with tighter spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4ec864ec83338eaf66dd885425c0