### PR TITLE
Align heading and widen NRW animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,8 @@
             font-family: 'Orbitron', monospace;
             font-size: 3.8rem;
             font-weight: 600;
-            margin-bottom: 30px;
+            text-align: left;
+            margin-bottom: 8px;
             letter-spacing: 6px;
             text-transform: uppercase;
             background: linear-gradient(135deg, #ffffff, #4facfe, #00f2fe);

--- a/nrwanimation/index.html
+++ b/nrwanimation/index.html
@@ -82,7 +82,7 @@
     // Pull the camera back further so the widened slope and enlarged characters
     // fit comfortably inside the frame.  A Z distance of 35 gives
     // ample room for the entire scene without cropping.
-    camera.position.set(0, 0, 35);
+    camera.position.set(0, 0, 40);
 
     // WebGL renderer
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
@@ -191,10 +191,10 @@
     // title above.  Feel free to adjust the X and Y values to fit your
     // layout perfectly.
     const positions = [
-      new THREE.Vector3(-8, 0.75, 0),  // Stage A: highest point, far left
-      new THREE.Vector3(-2.4, 0.3, 0), // Stage B: modest drop
-      new THREE.Vector3(2.4, 0.3, 0),  // Stage C: flat segment
-      new THREE.Vector3(8, -0.8, 0)    // Stage D: lowest point with steep drop
+      new THREE.Vector3(-12, 0.75, 0), // Stage A: highest point, far left
+      new THREE.Vector3(-4, 0.3, 0),   // Stage B: modest drop
+      new THREE.Vector3(4, 0.3, 0),    // Stage C: flat segment
+      new THREE.Vector3(12, -0.8, 0)   // Stage D: lowest point with steep drop
     ];
 
     // Create slope segments as thin glowing rectangles to emulate the descending line


### PR DESCRIPTION
## Summary
- Left-align main site heading and reduce its spacing.
- Expand NRW animation slope across the full width with wider figure placement and deeper camera.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f531814cc8333919f164827de46ef