### PR TITLE
Shrink NRW animation labels and remove frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,18 +946,9 @@
                         <h4 style="color: #8dd9ff; text-align: center; margin-bottom: 15px; font-family: 'Orbitron', sans-serif;">
                           Verteilung des politischen Wissens nach Kompetenzstufen für NRW
                         </h4>
-                        <iframe src="nrwanimation/index.html"
-                                alt="NRW Bildungsdaten Demokratiekompetenz"
-                                style="width: 100%;
-                                       height: 300px;
-                                       border: none;
-                                       border-radius: 8px;
-                                       border: 2px solid rgba(79, 172, 254, 0.4);
-                                       box-shadow: 0 0 15px rgba(79, 172, 254, 0.3), 0 0 30px rgba(79, 172, 254, 0.15), inset 0 0 10px rgba(79, 172, 254, 0.1);
-                                       margin: 20px 0;
-                                       position: relative;
-                                       z-index: 25;">
-                        </iframe>
+                         <iframe src="nrwanimation/index.html"
+                                 alt="NRW Bildungsdaten Demokratiekompetenz"
+                                 style="width: 100%; height: 300px; border: none;"></iframe>
 
                         <p class="content-text">Die Grafik zeigt, dass nur 36 % der Schülerinnen und Schüler in NRW über ein hohes konzeptionelles politisches Wissen verfügen. Gleichzeitig erreicht ein erheblicher Teil nur die unteren Kompetenzstufen.</p>
 

--- a/nrwanimation/index.html
+++ b/nrwanimation/index.html
@@ -5,8 +5,9 @@
   <title>NRW Kompetenzstufen Animation</title>
   <style>
     :root {
-      --number-font-size: 40px;
-      --desc-font-size: 24px;
+      /* Smaller defaults so labels stay subtle even before JS resizes them */
+      --number-font-size: 18px;
+      --desc-font-size: 12px;
     }
 
     /* Ensure the canvas takes up the entire window without scrollbars */
@@ -290,10 +291,11 @@
       camera.lookAt(center);
     }
 
-    function setLabelSizes() {
-      document.documentElement.style.setProperty('--number-font-size', (window.innerHeight * 0.14) + 'px');
-      document.documentElement.style.setProperty('--desc-font-size', (window.innerHeight * 0.08) + 'px');
-    }
+      function setLabelSizes() {
+        // Keep competency level labels and percentages small relative to figures
+        document.documentElement.style.setProperty('--number-font-size', (window.innerHeight * 0.06) + 'px');
+        document.documentElement.style.setProperty('--desc-font-size', (window.innerHeight * 0.04) + 'px');
+      }
     setLabelSizes();
 
     // Load textures and initialize sprites


### PR DESCRIPTION
## Summary
- shrink competency and percentage labels so they stay small relative to figures
- strip border/shadow container from NRW animation iframe

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5d9827d88333832455a57b96093d