### PR TITLE
Highlight 'ti' in Raumstation projects heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,7 +996,7 @@
                     <div class="content-wrapper">
                         <h3 class="content-title">Die Raumsta<span class="raumstation-ti">ti</span>on: Was, Wie, Warum</h3>
                         
-                        <h4>Was wir tun: Raumstation-Projekte</h4>
+                        <h4>Was wir tun: Raumsta<span class="raumstation-ti">ti</span>on-Projekte</h4>
                         <p class="content-text">Seit fünf Jahren setzen wir im gesamten Kreis Kleve Projekte in Kitas und Schulen um. Durch die Raumstation-Pädagogik werden Kinder und Jugendliche individuell gefördert und erwerben Kompetenzen, die sie befähigen, ihre Zukunft selbstbewusst und sicher zu gestalten.</p>
                         
                         <p class="content-text">Gemeinsam mit den Institutionen vor Ort entwickeln wir Formate, die passgenau sind und sich direkt in den Schul- und Kita-Alltag implementieren lassen.</p>


### PR DESCRIPTION
## Summary
- Apply the existing `raumstation-ti` glowing style to the "Raumstation" portion of the "Was wir tun: Raumstation-Projekte" heading for consistent branding.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f61bf2b448333a476e95526293471