### PR TITLE
Ensure headings remain left-aligned on mobile

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -430,6 +430,10 @@
 
         /* Responsive */
         @media (max-width: 768px) {
+            .main-content {
+                text-align: left;
+                align-items: flex-start;
+            }
             .main-content h1 {
                 font-size: 2.8rem;
                 letter-spacing: 2px;

--- a/impressum.html
+++ b/impressum.html
@@ -284,8 +284,8 @@
             content: '';
             position: absolute;
             bottom: -10px;
-            left: 50%;
-            transform: translateX(-50%);
+            left: 0;
+            transform: none;
             width: 100px;
             height: 2px;
             background: linear-gradient(90deg, transparent, #4facfe, transparent);
@@ -423,9 +423,14 @@
         }
 
         @media (max-width: 768px) {
+            .main-content {
+                text-align: left;
+                align-items: flex-start;
+            }
             .main-content h1 {
                 font-size: 2.8rem;
                 letter-spacing: 2px;
+                text-align: left !important;
             }
             
             .hamburger {

--- a/index.html
+++ b/index.html
@@ -324,8 +324,8 @@
             content: '';
             position: absolute;
             bottom: -10px;
-            left: 50%;
-            transform: translateX(-50%);
+            left: 0;
+            transform: none;
             width: 100px;
             height: 2px;
             background: linear-gradient(90deg, transparent, #4facfe, transparent);
@@ -749,6 +749,10 @@
         }
 
         @media (max-width: 768px) {
+            .main-content {
+                text-align: left;
+                align-items: flex-start;
+            }
             .main-content h1 {
                 font-size: 2.8rem;
                 letter-spacing: 2px;


### PR DESCRIPTION
## Summary
- Align main heading underline to the left across pages.
- Force left alignment for page headings on small screens for index, Impressum, and Datenschutz.

## Testing
- `npx -y htmlhint index.html impressum.html datenschutz.html`

------
https://chatgpt.com/codex/tasks/task_e_6891277d8224833390d9f091d5b0c270