### PR TITLE
Center underline on main headings

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -284,8 +284,8 @@
             content: '';
             position: absolute;
             bottom: -10px;
-            left: 0;
-            transform: none;
+            left: 50%;
+            transform: translateX(-50%);
             width: 100px;
             height: 2px;
             background: linear-gradient(90deg, transparent, #4facfe, transparent);

--- a/impressum.html
+++ b/impressum.html
@@ -284,8 +284,8 @@
             content: '';
             position: absolute;
             bottom: -10px;
-            left: 0;
-            transform: none;
+            left: 50%;
+            transform: translateX(-50%);
             width: 100px;
             height: 2px;
             background: linear-gradient(90deg, transparent, #4facfe, transparent);

--- a/index.html
+++ b/index.html
@@ -324,8 +324,8 @@
             content: '';
             position: absolute;
             bottom: -10px;
-            left: 0;
-            transform: none;
+            left: 50%;
+            transform: translateX(-50%);
             width: 100px;
             height: 2px;
             background: linear-gradient(90deg, transparent, #4facfe, transparent);


### PR DESCRIPTION
## Summary
- center the glowing pseudo-element under homepage and legal page headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913aa86110833389736e1790d84ae8