### PR TITLE
Fix Datenschutz header responsiveness

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -429,6 +429,27 @@
         }
 
         /* Responsive */
+        @media (max-width: 1200px) {
+            .nav {
+                gap: 30px;
+            }
+            .nav a {
+                font-size: 16px;
+                padding: 6px 12px;
+            }
+        }
+
+        @media (max-width: 900px) {
+            .nav {
+                gap: 20px;
+            }
+            .nav a {
+                font-size: 14px;
+                padding: 4px 8px;
+                letter-spacing: 1px;
+            }
+        }
+
         @media (max-width: 768px) {
             .main-content {
                 text-align: left;


### PR DESCRIPTION
## Summary
- add responsive breakpoints to Datenschutzh navigation so header scales like Impressum

## Testing
- `npx --yes htmlhint datenschutz.html`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913c683f288333b4f47c0aa89ff010