### PR TITLE
Remove leftover fluchtlinie guide line

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -331,17 +331,6 @@
             color: #e0e0e0;
         }
 
-        /* NUR ZUM TESTEN - Zeigt Fluchtlinien */
-        .main-content::before {
-            content: '';
-            position: absolute;
-            left: 40px; /* Gleicher Wert wie padding-left */
-            top: 0;
-            bottom: 0;
-            width: 1px;
-            background: red;
-            z-index: 9999;
-        }
 
         .datenschutz-content h2 {
             font-family: 'Orbitron', monospace;

--- a/impressum.html
+++ b/impressum.html
@@ -331,17 +331,6 @@
             color: #e0e0e0;
         }
 
-        /* NUR ZUM TESTEN - Zeigt Fluchtlinien */
-        .main-content::before {
-            content: '';
-            position: absolute;
-            left: 40px; /* Gleicher Wert wie padding-left */
-            top: 0;
-            bottom: 0;
-            width: 1px;
-            background: red;
-            z-index: 9999;
-        }
 
         .impressum-content h2 {
             font-family: 'Orbitron', monospace;

--- a/index.html
+++ b/index.html
@@ -333,17 +333,6 @@
             position: relative;
         }
 
-        /* NUR ZUM TESTEN - Zeigt Fluchtlinien */
-        .main-content::before {
-            content: '';
-            position: absolute;
-            left: 40px; /* Gleicher Wert wie padding-left */
-            top: 0;
-            bottom: 0;
-            width: 1px;
-            background: red;
-            z-index: 9999;
-        }
 
         .main-content h1 {
             font-family: 'Orbitron', monospace;


### PR DESCRIPTION
## Summary
- remove test-only CSS pseudo-element that drew a vertical red guide line from index, impressum, and datenschutz pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d687dfec83339abf41242f2bf9d1