### PR TITLE
Adjust legal page headings for better fit

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -288,7 +288,7 @@
 
         .main-content h1 {
             font-family: 'Orbitron', monospace;
-            font-size: clamp(2rem, 5vw, 3.8rem); /* Responsive Schriftgröße */
+            font-size: clamp(1.8rem, 4vw, 3rem); /* Responsive Schriftgröße */
             font-weight: 600;
             text-align: left;
             margin-left: 0 !important;  /* KEIN extra Margin */
@@ -297,7 +297,7 @@
             padding-right: 0 !important;
             width: 100%; /* Volle verfügbare Breite */
             margin-bottom: 8px;
-            letter-spacing: clamp(1px, 1vw, 6px); /* Responsive Letter-spacing */
+            letter-spacing: clamp(1px, 0.8vw, 4px); /* Responsive Letter-spacing */
             text-transform: uppercase;
             color: #ffffff;
             background: linear-gradient(135deg, #ffffff, #4facfe, #00f2fe);

--- a/impressum.html
+++ b/impressum.html
@@ -288,7 +288,7 @@
 
         .main-content h1 {
             font-family: 'Orbitron', monospace;
-            font-size: clamp(2rem, 5vw, 3.8rem); /* Responsive Schriftgröße */
+            font-size: clamp(1.8rem, 4vw, 3rem); /* Responsive Schriftgröße */
             font-weight: 600;
             text-align: left;
             margin-left: 0 !important;  /* KEIN extra Margin */
@@ -297,7 +297,7 @@
             padding-right: 0 !important;
             width: 100%; /* Volle verfügbare Breite */
             margin-bottom: 8px;
-            letter-spacing: clamp(1px, 1vw, 6px); /* Responsive Letter-spacing */
+            letter-spacing: clamp(1px, 0.8vw, 4px); /* Responsive Letter-spacing */
             text-transform: uppercase;
             color: #ffffff;
             background: linear-gradient(135deg, #ffffff, #4facfe, #00f2fe);


### PR DESCRIPTION
## Summary
- Reduce `.main-content h1` font size and letter spacing on `datenschutz.html` to prevent the "Datenschutzerklärung" heading from being cut off.
- Apply the same heading size adjustments on `impressum.html` so both pages match.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d823a24c833396e788dcb061a433