### PR TITLE
Reposition images and update team section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1049,7 +1049,9 @@
                     <div class="content-wrapper">
                         <h4>Wie wir es tun: Raumstation-Pädagogik</h4>
                         <p class="content-text">Die Raumstation-Pädagogik verwandelt pädagogische Situationen in sichere Räume, in denen Kinder eine intensive und prägende Zeit erleben.</p>
-                        
+
+                        <img src="images/demokratie3.gif" alt="Methodische Vielfalt" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(102, 126, 234, 0.4); box-shadow: 0 0 15px rgba(102, 126, 234, 0.3), 0 0 30px rgba(102, 126, 234, 0.15), inset 0 0 10px rgba(102, 126, 234, 0.1); margin: 20px 0;">
+
                         <div class="content-highlight">
                             <p style="font-weight: 600; margin-bottom: 15px; color: #667eea;">Ihre Merkmale:</p>
                             <ul class="content-list">
@@ -1064,10 +1066,6 @@
                         </div>
 
                         <p class="content-text">Der methodische Ansatz der Raumstation verbindet Bewährtes mit Neuem. Wir setzen auf traditionelle pädagogische Methoden, die Kindern ermöglichen, die Welt mit allen Sinnen zu erfahren.</p>
-
-                        <img src="images/demokratie3.gif" alt="Methodische Vielfalt" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(102, 126, 234, 0.4); box-shadow: 0 0 15px rgba(102, 126, 234, 0.3), 0 0 30px rgba(102, 126, 234, 0.15), inset 0 0 10px rgba(102, 126, 234, 0.1); margin: 20px 0;">
-
-                        <img src="images/interviews.gif" alt="Pädagogische Prinzipien" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(102, 126, 234, 0.4); box-shadow: 0 0 15px rgba(102, 126, 234, 0.3), 0 0 30px rgba(102, 126, 234, 0.15), inset 0 0 10px rgba(102, 126, 234, 0.1); margin: 20px 0;">
                     </div>
                 </div>
 
@@ -1081,6 +1079,8 @@
                         <p class="content-text">Wir wollen, dass Kinder nicht ohnmächtig vor Zukunftsproblemen stehen, sondern sie gestalten lernen. Unsere Projekte hinterlassen Wirkung, die bleibt. Sie prägen Haltungen, fördern Beteiligung und machen erfahrbar, dass Gesellschaft nur gemeinsam gelingt.</p>
                         
                         <p class="content-text">Gleichzeitig verstehen wir uns als Partner der Fachkräfte. Wir erkennen ihre Expertise und ihre wertvolle Arbeit an und stimmen uns eng mit ihnen ab, um ihre Bedarfe präzise aufzugreifen. Auf dieser Basis entwickeln wir passgenaue Formate, die sich in den Alltag der Institutionen einfügen.</p>
+
+                        <img src="images/interviews.gif" alt="Pädagogische Prinzipien" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(102, 126, 234, 0.4); box-shadow: 0 0 15px rgba(102, 126, 234, 0.3), 0 0 30px rgba(102, 126, 234, 0.15), inset 0 0 10px rgba(102, 126, 234, 0.1); margin: 20px 0;">
                     </div>
                 </div>
 
@@ -1091,15 +1091,14 @@
                     </div>
                     <div class="content-wrapper">
                         <h3 class="content-title" id="paedagogik">Wünschestadt – Kinder erkunden ihre Kommune</h3>
-                        
+                        <img src="images/WünschestadtGif1.gif" alt="Stadtbegehung aus der Kinderperspektive" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(86, 171, 47, 0.4); box-shadow: 0 0 15px rgba(86, 171, 47, 0.3), 0 0 30px rgba(86, 171, 47, 0.15), inset 0 0 10px rgba(86, 171, 47, 0.1); margin: 20px 0;">
+
                         <h4>Ein demokratisches Beteiligungsprojekt für Kinder in der Stadtplanung</h4>
                         <p class="content-text">Unser Projekt macht sichtbar, wie Kinder ihre Kommune erleben und gibt Impulse für eine Stadtplanung, die ihre Perspektiven ernst nimmt.</p>
                         
                         <p class="content-text">Welche Orte lieben sie? Wo fühlen sie sich sicher, wo unsicher? Gibt es Angsträume? Was fehlt ihnen? In Rundgängen durch ihre Stadt führen Kinder unser Raumstation-Team zu den Orten, die für sie Bedeutung haben.</p>
                         
                         <p class="content-text">So wird deutlich, wie die Stadt mit Kinderaugen wahrgenommen wird – eine wichtige Perspektive, die bislang in der Stadtplanung wenig Beachtung findet.</p>
-
-                        <img src="images/WünschestadtGif1.gif" alt="Stadtbegehung aus der Kinderperspektive" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(86, 171, 47, 0.4); box-shadow: 0 0 15px rgba(86, 171, 47, 0.3), 0 0 30px rgba(86, 171, 47, 0.15), inset 0 0 10px rgba(86, 171, 47, 0.1); margin: 20px 0;">
                     </div>
                 </div>
 
@@ -1111,12 +1110,12 @@
                     <div class="content-wrapper">
                         <h4>Methoden: Analog trifft Digital</h4>
                         <p class="content-text">Traditionelles Erleben und digitale Werkzeuge verbinden sich zu neuen Beteiligungsformen. Die gesamte Projektzeit ist Raumstation-Zeit. Während der Stadtbegehungen und in den kreativen Phasen danach kommen Kinder in all ihren Ausdrucksformen zu Wort.</p>
-                        
-                        <p class="content-text">Wir hören zu, beobachten und führen Interviews. Kinder malen, zeichnen oder bauen Modelle und setzen sich so mit ihrer Stadt auseinander. Digitale Methoden wie QR-Codes, Collagen oder Stop-Motion erweitern diese Möglichkeiten.</p>
-                        
-                        <p class="content-text">So entsteht ein besonderer Raum, in dem Kinder uns ihre Sichtweise näher bringen und uns zeigen, wie sie sich ihre Stadt wünschen – eben: Wünschestadt!</p>
 
                         <img src="images/Greenscreen.gif" alt="Verbindung von Analogem und Digitalem" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(86, 171, 47, 0.4); box-shadow: 0 0 15px rgba(86, 171, 47, 0.3), 0 0 30px rgba(86, 171, 47, 0.15), inset 0 0 10px rgba(86, 171, 47, 0.1); margin: 20px 0;">
+
+                        <p class="content-text">Wir hören zu, beobachten und führen Interviews. Kinder malen, zeichnen oder bauen Modelle und setzen sich so mit ihrer Stadt auseinander. Digitale Methoden wie QR-Codes, Collagen oder Stop-Motion erweitern diese Möglichkeiten.</p>
+
+                        <p class="content-text">So entsteht ein besonderer Raum, in dem Kinder uns ihre Sichtweise näher bringen und uns zeigen, wie sie sich ihre Stadt wünschen – eben: Wünschestadt!</p>
                     </div>
                 </div>
 
@@ -1141,7 +1140,7 @@
                         
                         <p class="content-text">So gewinnt Ihre Kommune Impulse, die unmittelbar in die Stadtentwicklung einfließen und zeigt gleichzeitig, dass sie Kinder und Jugendliche als wichtigen Teil der Gesellschaft wertschätzt.</p>
 
-                        <img src="images/crowd.gif" alt="Stadtplan aus Kinderperspektive" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(86, 171, 47, 0.4); box-shadow: 0 0 15px rgba(86, 171, 47, 0.3), 0 0 30px rgba(86, 171, 47, 0.15), inset 0 0 10px rgba(86, 171, 47, 0.1); margin: 20px 0;">
+                        <img src="images/gifemmerichpan.gif" alt="Stadtplan aus Kinderperspektive" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(86, 171, 47, 0.4); box-shadow: 0 0 15px rgba(86, 171, 47, 0.3), 0 0 30px rgba(86, 171, 47, 0.15), inset 0 0 10px rgba(86, 171, 47, 0.1); margin: 20px 0;">
                     </div>
                 </div>
 
@@ -1151,8 +1150,9 @@
                         <div class="planet-3d" id="orange-simple"></div>
                     </div>
                     <div class="content-wrapper">
-                        <h3 class="content-title" id="team">Das Team Raumstation: Wissenschaft & Praxis vereint</h3>
-                        
+                        <h3 class="content-title" id="team">Das Team Raumstation: Wir bringen Menschen für Kinderrechte zusammen. Wissenschaft & Praxis vereint</h3>
+                        <img src="images/crowd.gif" alt="Team Raumstation" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(255, 107, 53, 0.4); box-shadow: 0 0 15px rgba(255, 107, 53, 0.3), 0 0 30px rgba(255, 107, 53, 0.15), inset 0 0 10px rgba(255, 107, 53, 0.1); margin: 20px 0;">
+
                         <h4>Kinderrechte sind unser Fundament – Wertschätzung unser Prinzip</h4>
                         <p class="content-text">Kinder sind unsere Passion, ihre Rechte der Kompass unseres Handelns. Unser Ansatz: Wertschätzen statt bewerten.</p>
                         
@@ -1177,7 +1177,7 @@
                         
                         <p class="content-text">Unsere Stärke: Wir können analysieren, konzipieren und gleichzeitig anpacken.</p>
 
-                        <img src="images/gifemmerichpan.gif" alt="Beratungsexpertise" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(255, 107, 53, 0.4); box-shadow: 0 0 15px rgba(255, 107, 53, 0.3), 0 0 30px rgba(255, 107, 53, 0.15), inset 0 0 10px rgba(255, 107, 53, 0.1); margin: 20px 0;">
+                        <img src="images/crowd.gif" alt="Beratungsexpertise" style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px; border: 2px solid rgba(255, 107, 53, 0.4); box-shadow: 0 0 15px rgba(255, 107, 53, 0.3), 0 0 30px rgba(255, 107, 53, 0.15), inset 0 0 10px rgba(255, 107, 53, 0.1); margin: 20px 0;">
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Move Demokratie3 and Interviews gifs to match their corresponding text blocks.
- Position WünschestadtGif1 directly below its section heading and show Greenscreen gif before method description.
- Swap gifemmerichpan and crowd gifs, add crowd gif under updated team heading.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ebe7f03083339783eb985b81ac83