### PR TITLE
Prevent word breaks in heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,12 @@
             position: relative;
         }
 
+        .word-diskurs,
+        .word-niederrhein {
+            display: inline-block;
+            white-space: nowrap;
+        }
+
         .main-content h1::after {
             content: '';
             position: absolute;


### PR DESCRIPTION
## Summary
- keep "Diskurs" and "Niederrhein" words intact by wrapping each as inline-block and disabling internal wrapping

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689c843c61048333a326e467b731da9a